### PR TITLE
feat: migrate prod to Traefik

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,4 +1,4 @@
-name: CD for orgnote backend
+name: CD for orgnote backend (prod)
 
 on:
   workflow_run:
@@ -6,66 +6,73 @@ on:
       - CI for orgnote backend
     types:
       - completed
-    repository_dispatch:
-      types: [trigger-deploy-repo-workflow]
-
-env:
-  MONGO_USERNAME: ${{ secrets.MONGO_USERNAME }}
-  MONGO_PASSWORD: ${{ secrets.MONGO_PASSWORD }}
-  API_URL: ${{ vars.API_URL }}
-  GITHUB_ID: ${{ secrets.OAUTH_GITHUB_ID }}
-  GITHUB_SECRET: ${{ secrets.OAUTH_GITHUB_SECRET }}
-  CLIENT_ADDRESS: ${{ vars.CLIENT_ADDRESS }}
-  BACKEND_HOST: ${{ vars.BACKEND_HOST }}
-  BACKEND_DOMAIN: ${{ vars.BACKEND_DOMAIN }}
-  BACKEND_SCHEMA: ${{ vars.BACKEND_SCHEMA }}
-  ACCESS_CHECK_URL: ${{ vars.ACCESS_CHECK_URL }}
-  ACCESS_CHECK_TOKEN: ${{ secrets.ACCESS_CHECK_TOKEN }}
+    branches:
+      - master
 
 jobs:
   deploy:
-    name: Deploy
+    name: Deploy Production
     runs-on: ubuntu-latest
     if: >
       ${{ github.event.workflow_run.conclusion == 'success' && 
       github.event.workflow_run.head_branch == 'master' }}
-    environment: deploy
+    environment: production
     steps:
-      - name: deploy
+      - name: Deploy to production
         uses: fifsky/ssh-action@master
         with:
           host: ${{ secrets.SSH_HOST }}
           user: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          # TODO: master teplace .env with secrets
           command: |
-            cd ~/orgnote/orgnote-backend
-            docker compose -f docker-compose.db.yaml -f docker-compose.prod.yaml down
-            docker system prune -f
-            docker rmi orgnote/client:latest || true
+            mkdir -p ~/orgnote/prod
+            cd ~/orgnote/prod
+
+            if [ ! -d "orgnote-backend" ]; then
+              eval $(ssh-agent -s)
+              ssh-add ~/.ssh/sb-back
+              git clone git@github.com:Artawower/orgnote-backend.git
+            fi
+
+            cd orgnote-backend
             eval $(ssh-agent -s)
             ssh-add ~/.ssh/sb-back
-            git checkout master
             git fetch --all
+            git checkout master
             git reset --hard origin/master
 
-            cat <<EOT > .env
-            DEBUG=true
-            API_URL=${{ env.API_URL }}
-            MONGO_USERNAME=${{ env.MONGO_USERNAME }}
-            MONGO_PASSWORD=${{ env.MONGO_PASSWORD }}
-            GITHUB_ID=${{ env.GITHUB_ID }}
-            GITHUB_SECRET=${{ env.GITHUB_SECRET }}
-            CLIENT_ADDRESS=${{ env.CLIENT_ADDRESS }}
-            BACKEND_HOST=${{ env.BACKEND_HOST }}
-            BACKEND_DOMAIN=${{ env.BACKEND_DOMAIN }}
-            BACKEND_SCHEMA=${{ env.BACKEND_SCHEMA }}
-            ACCESS_CHECK_URL=${{ env.ACCESS_CHECK_URL }}
-            ACCESS_CHECK_TOKEN=${{ env.ACCESS_CHECK_TOKEN }}
+            cat <<EOT > .env.traefik
+            ACME_EMAIL=${{ secrets.ACME_EMAIL }}
+            EOT
+
+            cat <<EOT > .env.prod
+            DEBUG=false
+            MONGO_USERNAME=${{ secrets.MONGO_USERNAME }}
+            MONGO_PASSWORD=${{ secrets.MONGO_PASSWORD }}
+            GITHUB_ID=${{ secrets.OAUTH_GITHUB_ID }}
+            GITHUB_SECRET=${{ secrets.OAUTH_GITHUB_SECRET }}
+            CLIENT_ADDRESS=${{ vars.CLIENT_ADDRESS }}
+            BACKEND_DOMAIN=${{ vars.BACKEND_DOMAIN }}
+            BACKEND_SCHEMA=${{ vars.BACKEND_SCHEMA }}
+            BACKEND_PORT=${{ vars.BACKEND_PORT }}
+            ACCESS_CHECK_URL=${{ vars.ACCESS_CHECK_URL }}
+            ACCESS_CHECK_TOKEN=${{ secrets.ACCESS_CHECK_TOKEN }}
+            S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY_PROD }}
+            S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY_PROD }}
+            S3_BUCKET=${{ vars.S3_BUCKET_PROD }}
+            S3_USE_SSL=false
+            MAXIMUM_FILE_SIZE=52428800
             EOT
 
             docker login --username=${{ secrets.DOCKERHUB_USERNAME }} --password=${{ secrets.DOCKERHUB_TOKEN }}
-            docker pull orgnote/client
+            docker pull orgnote/client:latest
 
-            docker compose -f docker-compose.db.yaml -f docker-compose.prod.yaml up --build -d
+            # Traefik: start only if not running (shared between environments)
+            if ! docker ps --format '{{.Names}}' | grep -q '^orgnote-traefik$'; then
+              docker compose -f docker-compose.traefik.yaml --env-file .env.traefik up -d
+            fi
+
+            docker compose -f docker-compose.db.prod.yaml -f docker-compose.prod.yaml --env-file .env.prod up -d --build
+
+            docker system prune -f
           args: "-tt"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3-alpine
+FROM golang:1.24-alpine
 
 WORKDIR /workspace
 ENV GO111MODULE=on

--- a/deploy/traefik/traefik.yaml
+++ b/deploy/traefik/traefik.yaml
@@ -1,0 +1,30 @@
+api:
+  dashboard: false
+
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+  websecure:
+    address: ":443"
+
+providers:
+  docker:
+    endpoint: "unix:///var/run/docker.sock"
+    exposedByDefault: false
+    network: traefik-network
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: ${ACME_EMAIL}
+      storage: /letsencrypt/acme.json
+      httpChallenge:
+        entryPoint: web
+
+log:
+  level: INFO

--- a/docker-compose.db.prod.yaml
+++ b/docker-compose.db.prod.yaml
@@ -1,0 +1,57 @@
+services:
+  orgnote-mongo-prod:
+    container_name: orgnote-mongo-prod
+    image: mongo:5.0.9
+    restart: always
+    logging:
+      driver: none
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USERNAME}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
+    volumes:
+      - orgnote-mongo-prod-data:/data/db
+    networks:
+      - orgnote-prod-network
+    command: [--auth]
+
+  orgnote-minio-prod:
+    image: minio/minio:latest
+    container_name: orgnote-minio-prod
+    restart: always
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${S3_ACCESS_KEY}
+      MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY}
+    volumes:
+      - orgnote-minio-prod-data:/data
+    networks:
+      - orgnote-prod-network
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  orgnote-minio-init-prod:
+    image: minio/mc:latest
+    container_name: orgnote-minio-init-prod
+    depends_on:
+      orgnote-minio-prod:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set orgnote http://orgnote-minio-prod:9000 ${S3_ACCESS_KEY} ${S3_SECRET_KEY};
+      mc mb --ignore-existing orgnote/${S3_BUCKET};
+      echo 'Bucket created successfully';
+      "
+    networks:
+      - orgnote-prod-network
+
+volumes:
+  orgnote-mongo-prod-data:
+  orgnote-minio-prod-data:
+
+networks:
+  orgnote-prod-network:
+    name: orgnote-prod-network
+    driver: bridge

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,86 +1,73 @@
-version: "3.8"
-
 services:
-  orgnote_backend:
+  orgnote-backend-prod:
+    container_name: orgnote-backend-prod
     restart: always
-    container_name: orgnote_backend
+    depends_on:
+      - orgnote-mongo-prod
+      - orgnote-minio-prod
     build:
       context: .
       dockerfile: Dockerfile
-    # ports:
-    #   - 3000:3000
     networks:
-      - orgnote_network
-    depends_on:
-      - orgnote_mongo
+      - orgnote-prod-network
+      - traefik-network
+
     volumes:
-      - ./media:/workspace/media
+      - ./media/prod:/workspace/media
     env_file:
-      - .env
-    healthcheck:
-      test: ["CMD-SHELL", "curl", "-f", "${MONGO_URL}:${MONGO_PORT}"]
-      timeout: 1s
-      interval: 2s
-      retries: 10
+      - .env.prod
     environment:
-      - MONGO_USERNAME=${MONGO_USERNAME}
-      - MONGO_URL=orgnote_mongo
-      - MONGO_PASSWORD=${MONGO_PASSWORD}
+      - MONGO_URL=orgnote-mongo-prod
       - MONGO_PORT=27017
       - APP_ADDRESS=0.0.0.0:3000
-      - GITHUB_ID=${GITHUB_ID}
-      - GITHUB_SECRET=${GITHUB_SECRET}
-      - BACKEND_DOMAIN=${BACKEND_DOMAIN}
-      - BACKEND_SCHEMA=${BACKEND_SCHEMA}
-      - BACKEND_PORT=${BACKEND_PORT}
-      - CLIENT_ADDRESS=${CLIENT_ADDRESS}
-      - ACCESS_CHECK_URL=${ACCESS_CHECK_URL}
-      - ACCESS_CHECK_TOKEN=${ACCESS_CHECK_TOKEN}
-      - DEBUG=${DEBUG}
+      - S3_ENDPOINT=orgnote-minio-prod:9000
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.backend-prod.rule=Host(`org-note.com`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.backend-prod.entrypoints=websecure"
+      - "traefik.http.routers.backend-prod.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.backend-prod.middlewares=backend-prod-strip"
+      - "traefik.http.middlewares.backend-prod-strip.stripprefix.prefixes=/api"
+      - "traefik.http.services.backend-prod.loadbalancer.server.port=3000"
+      - "traefik.docker.network=traefik-network"
 
-  orgnote_cors:
+  orgnote-cors-prod:
     image: bassetts/warp-cors
-    container_name: orgnote_cors
-    networks:
-      - orgnote_network
-    ports:
-      - 3030:3030
-
-  orgnote_nginx:
+    container_name: orgnote-cors-prod
     restart: always
-    container_name: orgnote_nginx
-    image: nginx:stable
-    ports:
-      - 80:80
-    expose:
-      - 80
-    volumes:
-      - ~/frontend-build:/opt/services/frontend:rw
-      - ./deploy/nginx/conf.d:/etc/nginx/conf.d:rw
-      - ./media:/opt/services/backend/media:rw
-      - ./static:/opt/services/backend/static:rw
-    depends_on:
-      - orgnote_backend
-      - orgnote_cors
-      - orgnote_client
-    links:
-      - orgnote_backend
-      - orgnote_cors
-      - orgnote_client
     networks:
-      - orgnote_network
-    command: ["/usr/sbin/nginx", "-g", "daemon off;"]
+      - orgnote-prod-network
+      - traefik-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.cors-prod.rule=Host(`org-note.com`) && PathPrefix(`/cors`)"
+      - "traefik.http.routers.cors-prod.entrypoints=websecure"
+      - "traefik.http.routers.cors-prod.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.cors-prod.middlewares=cors-prod-strip"
+      - "traefik.http.middlewares.cors-prod-strip.stripprefix.prefixes=/cors"
+      - "traefik.http.services.cors-prod.loadbalancer.server.port=3030"
+      - "traefik.docker.network=traefik-network"
 
-  orgnote_client:
+  orgnote-client-prod:
     image: orgnote/client:latest
-    container_name: orgnote_client
+    container_name: orgnote-client-prod
+    restart: always
     environment:
       - DISABLE_LOGGER=1
     networks:
-      - orgnote_network
-    # ports:
-    #   - "3060:3000"
+      - orgnote-prod-network
+      - traefik-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.client-prod.rule=Host(`org-note.com`)"
+      - "traefik.http.routers.client-prod.entrypoints=websecure"
+      - "traefik.http.routers.client-prod.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.client-prod.priority=1"
+      - "traefik.http.services.client-prod.loadbalancer.server.port=3000"
+      - "traefik.docker.network=traefik-network"
 
 networks:
-  orgnote_network:
-    driver: bridge
+  orgnote-prod-network:
+    external: true
+  traefik-network:
+    external: true

--- a/docker-compose.traefik.yaml
+++ b/docker-compose.traefik.yaml
@@ -1,0 +1,24 @@
+services:
+  traefik:
+    image: traefik:v3.0
+    container_name: orgnote-traefik
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./deploy/traefik/traefik.yaml:/etc/traefik/traefik.yaml:ro
+      - traefik-letsencrypt:/letsencrypt
+    environment:
+      - ACME_EMAIL=${ACME_EMAIL}
+    networks:
+      - traefik-network
+
+volumes:
+  traefik-letsencrypt:
+
+networks:
+  traefik-network:
+    name: traefik-network
+    driver: bridge


### PR DESCRIPTION
## Summary
- Replace nginx with Traefik reverse proxy
- Add MinIO for S3-compatible storage
- Update Dockerfile to Go 1.24
- Update CD workflow for new architecture

## Breaking Changes
First deployment will require manual cleanup of old containers on server:
```bash
docker stop orgnote_nginx orgnote_client orgnote_backend orgnote_cors orgnote_mongo
docker rm orgnote_nginx orgnote_client orgnote_backend orgnote_cors orgnote_mongo
```

## New GitHub Secrets/Variables needed
**Secrets:**
- `ACME_EMAIL` - for Let's Encrypt
- `S3_ACCESS_KEY_PROD`
- `S3_SECRET_KEY_PROD`

**Variables:**
- `S3_BUCKET_PROD`