### PR TITLE
fix: preserve MongoDB data during migration

### DIFF
--- a/docker-compose.db.prod.yaml
+++ b/docker-compose.db.prod.yaml
@@ -49,6 +49,8 @@ services:
 
 volumes:
   orgnote-mongo-prod-data:
+    external: true
+    name: mongodb_data_container
   orgnote-minio-prod-data:
 
 networks:


### PR DESCRIPTION
Use existing `mongodb_data_container` volume to preserve prod data during Traefik migration.