### PR TITLE
fix: let docker compose create networks automatically

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -68,6 +68,6 @@ services:
 
 networks:
   orgnote-prod-network:
-    external: true
+    name: orgnote-prod-network
   traefik-network:
-    external: true
+    name: traefik-network


### PR DESCRIPTION
Remove external: true from networks so docker compose creates them automatically.