### PR TITLE
fix(docker): correct mongodb volume name for prod

### DIFF
--- a/docker-compose.db.prod.yaml
+++ b/docker-compose.db.prod.yaml
@@ -50,7 +50,7 @@ services:
 volumes:
   orgnote-mongo-prod-data:
     external: true
-    name: mongodb_data_container
+    name: orgnote-backend_mongodb_data_container
   orgnote-minio-prod-data:
 
 networks:


### PR DESCRIPTION
## Summary
- Fix external MongoDB volume name from `mongodb_data_container` to `orgnote-backend_mongodb_data_container`
- Docker Compose prefixes volume names with project name, so the actual volume on server has this prefix

## Test plan
- [ ] Merge to master
- [ ] CD deploys successfully
- [ ] `docker ps` shows prod containers running
- [ ] MongoDB data preserved

🤖 Generated with [eca](https://eca.dev)