### PR TITLE
fix(ci): always update traefik, fix dev depends_on

### DIFF
--- a/.github/workflows/cd.dev.yaml
+++ b/.github/workflows/cd.dev.yaml
@@ -25,6 +25,13 @@ jobs:
           user: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           command: |
+            # Ensure just is installed
+            if ! command -v just &> /dev/null; then
+              curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to ~/bin
+              export PATH="$HOME/bin:$PATH"
+            fi
+            export PATH="$HOME/bin:$PATH"
+
             mkdir -p ~/orgnote/dev
             cd ~/orgnote/dev
 
@@ -67,13 +74,6 @@ jobs:
             docker login --username=${{ secrets.DOCKERHUB_USERNAME }} --password=${{ secrets.DOCKERHUB_TOKEN }}
             docker pull orgnote/client:dev 2>/dev/null || true
 
-            # Traefik: start only if not running (shared between environments)
-            if ! docker ps --format '{{.Names}}' | grep -q '^orgnote-traefik$'; then
-              docker compose -f docker-compose.traefik.yaml --env-file .env.traefik up -d
-            fi
-
-            docker compose -f docker-compose.db.dev.yaml --env-file .env.dev up -d
-            docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d --build
-
-            docker system prune -f
+            just deploy-dev
+            just prune
           args: "-tt"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -25,6 +25,13 @@ jobs:
           user: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           command: |
+            # Ensure just is installed
+            if ! command -v just &> /dev/null; then
+              curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to ~/bin
+              export PATH="$HOME/bin:$PATH"
+            fi
+            export PATH="$HOME/bin:$PATH"
+
             mkdir -p ~/orgnote/prod
             cd ~/orgnote/prod
 
@@ -67,12 +74,6 @@ jobs:
             docker login --username=${{ secrets.DOCKERHUB_USERNAME }} --password=${{ secrets.DOCKERHUB_TOKEN }}
             docker pull orgnote/client:latest
 
-            # Traefik: start only if not running (shared between environments)
-            if ! docker ps --format '{{.Names}}' | grep -q '^orgnote-traefik$'; then
-              docker compose -f docker-compose.traefik.yaml --env-file .env.traefik up -d
-            fi
-
-            docker compose -f docker-compose.db.prod.yaml -f docker-compose.prod.yaml --env-file .env.prod up -d --build
-
-            docker system prune -f
+            just deploy-prod
+            just prune
           args: "-tt"

--- a/justfile
+++ b/justfile
@@ -1,0 +1,69 @@
+# OrgNote Backend - Deployment Commands
+
+# Default recipe
+default:
+    @just --list
+
+# === LOCAL DEVELOPMENT ===
+
+local:
+    docker compose -f docker-compose.db.local.yaml up -d
+    docker compose -f docker-compose.local.yaml --env-file .env.local up --build
+
+local-down:
+    docker compose -f docker-compose.local.yaml down
+    docker compose -f docker-compose.db.local.yaml down
+
+# === TRAEFIK (shared) ===
+
+traefik:
+    docker compose -f docker-compose.traefik.yaml --env-file .env.traefik up -d
+
+traefik-logs:
+    docker logs orgnote-traefik -f
+
+# === PRODUCTION ===
+
+deploy-prod:
+    docker compose -f docker-compose.traefik.yaml --env-file .env.traefik up -d
+    docker compose -f docker-compose.db.prod.yaml -f docker-compose.prod.yaml --env-file .env.prod up -d --build
+
+prod-down:
+    docker compose -f docker-compose.prod.yaml down
+    docker compose -f docker-compose.db.prod.yaml down
+
+prod-logs:
+    docker compose -f docker-compose.prod.yaml logs -f
+
+prod-logs-backend:
+    docker logs orgnote-backend-prod -f
+
+# === DEVELOPMENT (server) ===
+
+deploy-dev:
+    docker compose -f docker-compose.traefik.yaml --env-file .env.traefik up -d
+    docker compose -f docker-compose.db.dev.yaml -f docker-compose.dev.yaml --env-file .env.dev up -d --build
+
+dev-down:
+    docker compose -f docker-compose.dev.yaml down
+    docker compose -f docker-compose.db.dev.yaml down
+
+dev-logs:
+    docker compose -f docker-compose.dev.yaml logs -f
+
+dev-logs-backend:
+    docker logs orgnote-backend-dev -f
+
+# === UTILITIES ===
+
+prune:
+    docker system prune -f
+
+ps:
+    docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+
+# Check all services status
+status:
+    @echo "=== Traefik ===" && docker ps --filter name=orgnote-traefik --format "{{.Names}}: {{.Status}}" || true
+    @echo "=== Prod ===" && docker ps --filter name=-prod --format "{{.Names}}: {{.Status}}" || true
+    @echo "=== Dev ===" && docker ps --filter name=-dev --format "{{.Names}}: {{.Status}}" || true


### PR DESCRIPTION
## Summary
- Remove condition that skipped Traefik update if container already running (caused stale config)
- Combine db and app compose files for dev deployment (fixes `depends_on undefined service` error)

## Test plan
- [ ] Merge to master
- [ ] Dev CD runs and deploys dev containers successfully
- [ ] `docker ps | grep dev` shows backend-dev and client-dev
- [ ] dev.org-note.com accessible

🤖 Generated with [eca](https://eca.dev)